### PR TITLE
deselect button

### DIFF
--- a/src/littlefoot.css
+++ b/src/littlefoot.css
@@ -47,7 +47,6 @@
   vertical-align: middle;
 
   &:hover,
-  &:focus,
   &:active,
   &.is-active {
     background-color: var(--button-active-background-color);


### PR DESCRIPTION
Deselect the footnote button when clicking again to minimize the footnote. The button will still highlight when hovering.